### PR TITLE
fix: change subscription status to 'on_hold' when paused

### DIFF
--- a/dodo-payments-for-woocommerce.php
+++ b/dodo-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://dodopayments.com
  * Short Description: Accept payments globally within minutes.
  * Description: Dodo Payments plugin for WooCommerce. Accept payments from your customers using Dodo Payments.
- * Version: 0.3.2
+ * Version: 0.3.3
  * Author: Dodo Payments
  * Developer: Dodo Payments
  * Text Domain: dodo-payments-for-woocommerce
@@ -921,6 +921,8 @@ function dodo_payments_init()
                                 );
                                 return;
                             }
+
+                            $dodo_subscription = $this->dodo_payments_api->get_subscription($subscription_id);
 
                             $this->create_renewal_order($subscription, $payment_id);
                         }

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -764,7 +764,7 @@ class Dodo_Payments_API
     /**
      * Pauses an active subscription in the Dodo Payments API.
      *
-     * Sets the subscription status to 'paused' for the specified subscription ID. Throws an exception if the API request fails.
+     * Sets the subscription status to 'on_hold' for the specified subscription ID. Throws an exception if the API request fails.
      *
      * @param string $dodo_subscription_id The ID of the subscription to pause.
      * @throws \Exception If the API request fails or returns an error response.
@@ -772,7 +772,7 @@ class Dodo_Payments_API
     public function pause_subscription($dodo_subscription_id)
     {
         $body = array(
-            'status' => 'paused'
+            'status' => 'on_hold'
         );
 
         $res = $this->patch("/subscriptions/{$dodo_subscription_id}", $body);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ayushdodopayments
 Tags: payments, woocommerce, dodo
 Requires at least: 6.1
 Tested up to: 6.8
-Stable tag: 0.3.2
+Stable tag: 0.3.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,9 @@ Dodo Payments for WooCommerce is a comprehensive payment solution that handles a
 Currently, we support credit card payments through Dodo Payment Gateway.
 
 == Changelog ==
+
+= 0.3.3 =
+* fix: change subscription status to 'on_hold' instead of invalid state of 'paused' when a subscription is paused in woocommerce.
 
 = 0.3.2 =
 * fix: add missing import for cart exceptions which prevented cart errors from being displayed properly


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription status now correctly changes to 'on_hold' when paused in WooCommerce.

* **Chores**
  * Version updated to 0.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->