### PR TITLE
bump tested-up-to WordPress version to 6.9

### DIFF
--- a/dodo-payments-for-woocommerce.php
+++ b/dodo-payments-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Requires PHP: 7.4
  * Requires at least: 6.1
  * Requires Plugins: woocommerce
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * WC requires at least: 7.9
  * WC tested up to: 9.6
  */


### PR DESCRIPTION
## Summary

Bumps the WordPress "Tested up to" version header in the main plugin file from `6.8` to `6.9`.

## Issue

The plugin header declared compatibility only up to WordPress 6.8. WordPress 6.9 has been released and users on that version may see compatibility warnings in the WordPress admin dashboard, which can erode trust in the plugin.

## Root Cause

The `Tested up to` field in `dodo-payments-for-woocommerce.php` was not updated after WordPress 6.9 was released.

## Fix

Updated the single line in the plugin header:

```
- * Tested up to: 6.8
+ * Tested up to: 6.9
```

## Validation

- Change is a metadata-only header update; no functional code was modified.
- Verified the plugin loads and operates correctly on WordPress 6.9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin compatibility declaration to reflect latest tested WordPress version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->