### PR TITLE
Limit product names to 100 characters in Dodo API requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Dodo Payments for WooCommerce Changelog ***
 
+2026-04-17 - version 0.3.5
+* Fix: truncate product names to 100 characters to prevent API validation errors
+
 2025-07-09 - version 0.3.1
 * Fix: use plain permalink structure for webhook url which is more widely supported
 

--- a/dodo-payments-for-woocommerce.php
+++ b/dodo-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://dodopayments.com
  * Short Description: Accept payments globally within minutes.
  * Description: Dodo Payments plugin for WooCommerce. Accept payments from your customers using Dodo Payments.
- * Version: 0.3.4
+ * Version: 0.3.5
  * Author: Dodo Payments
  * Developer: Dodo Payments
  * Text Domain: dodo-payments-for-woocommerce

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -43,7 +43,7 @@ class Dodo_Payments_API
         $truncated_description = mb_substr($stripped_description, 0, min(999, mb_strlen($stripped_description)));
 
         $body = array(
-            'name' => $product->get_name(),
+            'name' => mb_substr($product->get_name(), 0, 100),
             'description' => $truncated_description,
             'price' => array(
                 'type' => 'one_time_price',
@@ -92,7 +92,7 @@ class Dodo_Payments_API
         // ignore global options, respect the tax_category and tax_inclusive set
         // from the dashboard
         $body = array(
-            'name' => $product->get_name(),
+            'name' => mb_substr($product->get_name(), 0, 100),
             'description' => $truncated_description,
             'price' => array(
                 'type' => 'one_time_price',
@@ -497,7 +497,7 @@ class Dodo_Payments_API
         );
 
         $body = array(
-            'name' => $product->get_name(),
+            'name' => mb_substr($product->get_name(), 0, 100),
             'description' => $truncated_description,
             'price' => $price_data,
             'tax_category' => $this->global_tax_category,
@@ -598,7 +598,7 @@ class Dodo_Payments_API
         );
 
         $body = array(
-            'name' => $product->get_name(),
+            'name' => mb_substr($product->get_name(), 0, 100),
             'description' => $truncated_description,
             'price' => $price_data,
             'tax_category' => $dodo_product['tax_category'],

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -2,6 +2,9 @@
 
 class Dodo_Payments_API
 {
+    private const MAX_PRODUCT_NAME_LENGTH = 100;
+    private const MAX_PRODUCT_DESCRIPTION_LENGTH = 999;
+
     private bool $testmode;
     private string $api_key;
     /**
@@ -40,10 +43,10 @@ class Dodo_Payments_API
     public function create_product($product)
     {
         $stripped_description = wp_strip_all_tags($product->get_description());
-        $truncated_description = mb_substr($stripped_description, 0, min(999, mb_strlen($stripped_description)));
+        $truncated_description = mb_substr($stripped_description, 0, self::MAX_PRODUCT_DESCRIPTION_LENGTH);
 
         $body = array(
-            'name' => mb_substr($product->get_name(), 0, 100),
+            'name' => mb_substr($product->get_name(), 0, self::MAX_PRODUCT_NAME_LENGTH),
             'description' => $truncated_description,
             'price' => array(
                 'type' => 'one_time_price',
@@ -87,12 +90,12 @@ class Dodo_Payments_API
         }
 
         $stripped_description = wp_strip_all_tags($product->get_description());
-        $truncated_description = mb_substr($stripped_description, 0, min(999, mb_strlen($stripped_description)));
+        $truncated_description = mb_substr($stripped_description, 0, self::MAX_PRODUCT_DESCRIPTION_LENGTH);
 
         // ignore global options, respect the tax_category and tax_inclusive set
         // from the dashboard
         $body = array(
-            'name' => mb_substr($product->get_name(), 0, 100),
+            'name' => mb_substr($product->get_name(), 0, self::MAX_PRODUCT_NAME_LENGTH),
             'description' => $truncated_description,
             'price' => array(
                 'type' => 'one_time_price',
@@ -436,7 +439,7 @@ class Dodo_Payments_API
         }
 
         $stripped_description = wp_strip_all_tags($product->get_description());
-        $truncated_description = mb_substr($stripped_description, 0, min(999, mb_strlen($stripped_description)));
+        $truncated_description = mb_substr($stripped_description, 0, self::MAX_PRODUCT_DESCRIPTION_LENGTH);
 
         // Get subscription details
         $period = WC_Subscriptions_Product::get_period($product);
@@ -497,7 +500,7 @@ class Dodo_Payments_API
         );
 
         $body = array(
-            'name' => mb_substr($product->get_name(), 0, 100),
+            'name' => mb_substr($product->get_name(), 0, self::MAX_PRODUCT_NAME_LENGTH),
             'description' => $truncated_description,
             'price' => $price_data,
             'tax_category' => $this->global_tax_category,
@@ -538,7 +541,7 @@ class Dodo_Payments_API
         }
 
         $stripped_description = wp_strip_all_tags($product->get_description());
-        $truncated_description = mb_substr($stripped_description, 0, min(999, mb_strlen($stripped_description)));
+        $truncated_description = mb_substr($stripped_description, 0, self::MAX_PRODUCT_DESCRIPTION_LENGTH);
 
         $period = WC_Subscriptions_Product::get_period($product);
         $period_count = WC_Subscriptions_Product::get_interval($product);
@@ -598,7 +601,7 @@ class Dodo_Payments_API
         );
 
         $body = array(
-            'name' => mb_substr($product->get_name(), 0, 100),
+            'name' => mb_substr($product->get_name(), 0, self::MAX_PRODUCT_NAME_LENGTH),
             'description' => $truncated_description,
             'price' => $price_data,
             'tax_category' => $dodo_product['tax_category'],

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ayushdodopayments
 Tags: payments, woocommerce, dodo payments, merchant of record, subscriptions
 Requires at least: 6.1
 Tested up to: 6.9
-Stable tag: 0.3.4
+Stable tag: 0.3.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## Summary
This PR adds character length validation to product names sent to the Dodo Payments API by truncating them to a maximum of 100 characters using `mb_substr()`.

## Key Changes
- Added `mb_substr()` truncation to product names in `create_product()` method
- Added `mb_substr()` truncation to product names in `update_product()` method
- Added `mb_substr()` truncation to product names in `create_subscription_product()` method
- Added `mb_substr()` truncation to product names in `update_subscription_product()` method

## Implementation Details
- Uses `mb_substr($product->get_name(), 0, 100)` to safely truncate product names while respecting multibyte character boundaries
- Consistent with the existing pattern used for description truncation in the same methods
- Ensures API compliance by enforcing the 100-character limit across all product creation and update operations, including both regular and subscription products

https://claude.ai/code/session_01FuntH3rmdCuHUEk8kbcXHe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed product name handling when syncing with Dodo Payments API. Product names are now automatically truncated to 100 characters during creation and updates to ensure proper API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->