### PR TITLE
Migrate to Checkout Sessions API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Dodo Payments for WooCommerce Changelog ***
 
+2026-05-19 - version 0.4.0
+* Migration: Switched payment and subscription creation from the deprecated `POST /payments` and `POST /subscriptions` endpoints to the unified Checkout Sessions API (`POST /checkouts`).
+* Enhancement: WooCommerce order id (and subscription id, when applicable) are now passed as Dodo Payments checkout-session metadata so webhooks can resolve the originating order even before the first payment id is known.
+* Enhancement: Webhook handlers now lazily create the local order/subscription mapping from the metadata on the first inbound event, since checkout sessions no longer return `payment_id`/`subscription_id` at creation time.
+
 2026-04-17 - version 0.3.5
 * Fix: truncate product names to 100 characters to prevent API validation errors
 

--- a/dodo-payments-for-woocommerce.php
+++ b/dodo-payments-for-woocommerce.php
@@ -86,13 +86,25 @@ function dodo_payments_init()
                 $this->method_title = __('Dodo Payments', 'dodo-payments-for-woocommerce');
                 $this->method_description = __('Accept payments via Dodo Payments.', 'dodo-payments-for-woocommerce');
 
-                // Declare subscription support
+                // Declare subscription support.
+                //
+                // `gateway_scheduled_payments` tells WooCommerce Subscriptions that
+                // Dodo Payments schedules and bills renewals itself, so WCS should NOT
+                // run its own renewal scheduler against these subscriptions. Without
+                // this token WCS would flip every active Dodo subscription to on-hold
+                // at its locally-scheduled renewal time and create an orphan renewal
+                // order, even though Dodo would have gone on to bill the customer
+                // successfully on its own schedule. The plugin satisfies the contract
+                // by reacting to inbound `payment.succeeded` webhooks (with a
+                // subscription_id) and creating the matching WC renewal order via
+                // `handle_payment_webhook` -> `create_renewal_order`.
                 $this->supports = array(
                     'products',
                     'subscriptions',
                     'subscription_cancellation',
                     'subscription_suspension',
                     'subscription_reactivation',
+                    'gateway_scheduled_payments',
                 );
 
                 $this->enabled = $this->get_option('enabled');

--- a/dodo-payments-for-woocommerce.php
+++ b/dodo-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://dodopayments.com
  * Short Description: Accept payments globally within minutes.
  * Description: Dodo Payments plugin for WooCommerce. Accept payments from your customers using Dodo Payments.
- * Version: 0.3.5
+ * Version: 0.4.0
  * Author: Dodo Payments
  * Developer: Dodo Payments
  * Text Domain: dodo-payments-for-woocommerce
@@ -354,19 +354,31 @@ function dodo_payments_init()
                         }
                     }
 
-                    $response = $contains_subscription
-                        ? $this->dodo_payments_api->create_subscription(
-                            $order,
-                            $synced_products,
-                            $dodo_discount_code,
-                            $this->get_return_url($order)
-                        )
-                        : $this->dodo_payments_api->create_payment(
-                            $order,
-                            $synced_products,
-                            $dodo_discount_code,
-                            $this->get_return_url($order)
-                        );
+                    // Pass the WooCommerce order id (and subscription id, if any) via
+                    // metadata so the webhook handlers can resolve the WC entities even
+                    // before any payment_id/subscription_id mapping is recorded locally.
+                    // The deprecated /payments and /subscriptions endpoints returned
+                    // those IDs synchronously, but POST /checkouts only returns a
+                    // checkout session id + url -- the resource IDs arrive via webhooks.
+                    $metadata = array(
+                        'wc_order_id' => (string) $order->get_id(),
+                    );
+
+                    if ($contains_subscription && function_exists('wcs_get_subscriptions_for_order')) {
+                        $wc_subscriptions = wcs_get_subscriptions_for_order($order->get_id());
+                        if (!empty($wc_subscriptions)) {
+                            $wc_subscription = reset($wc_subscriptions);
+                            $metadata['wc_subscription_id'] = (string) $wc_subscription->get_id();
+                        }
+                    }
+
+                    $response = $this->dodo_payments_api->create_checkout_session(
+                        $order,
+                        $synced_products,
+                        $dodo_discount_code,
+                        $this->get_return_url($order),
+                        $metadata
+                    );
                 } catch (Exception $e) {
                     $order->add_order_note(
                         sprintf(
@@ -379,74 +391,25 @@ function dodo_payments_init()
                     return array('result' => 'failure');
                 }
 
-                // Handle both payment and subscription responses
-                if ($contains_subscription) {
-                    if (isset($response['payment_link'])) {
-                        if (isset($response['subscription_id'])) {
-                            // Save the subscription mapping
-                            $subscription_order = wcs_get_subscriptions_for_order($order->get_id());
-                            if (!empty($subscription_order)) {
-                                $subscription = reset($subscription_order);
-                                Dodo_Payments_Subscription_DB::save_mapping($subscription->get_id(), $response['subscription_id']);
-
-                                $order->add_order_note(
-                                    sprintf(
-                                        // translators: %1$s: Subscription ID
-                                        __('Subscription created in Dodo Payments: %1$s', 'dodo-payments-for-woocommerce'),
-                                        $response['subscription_id']
-                                    )
-                                );
-                            }
-                        }
-
-                        if (isset($response['payment_id'])) {
-                            // Save the payment mapping
-                            Dodo_Payments_Payment_DB::save_mapping($order->get_id(), $response['payment_id']);
-
-                            $order->add_order_note(
-                                sprintf(
-                                    // translators: %1$s: Payment ID
-                                    __('Payment created in Dodo Payments: %1$s', 'dodo-payments-for-woocommerce'),
-                                    $response['payment_id']
-                                )
-                            );
-                        }
-
-
-                        return array(
-                            'result' => 'success',
-                            'redirect' => $response['payment_link']
-                        );
-                    } else {
-                        $order->add_order_note(
-                            __('Failed to create subscription in Dodo Payments: Invalid response', 'dodo-payments-for-woocommerce')
-                        );
-                        return array('result' => 'failure');
-                    }
-                } else {
-                    if (isset($response['payment_link']) && isset($response['payment_id'])) {
-                        // Save the payment mapping
-                        Dodo_Payments_Payment_DB::save_mapping($order->get_id(), $response['payment_id']);
-
-                        $order->add_order_note(
-                            sprintf(
-                                // translators: %1$s: Payment ID
-                                __('Payment created in Dodo Payments: %1$s', 'dodo-payments-for-woocommerce'),
-                                $response['payment_id']
-                            )
-                        );
-
-                        return array(
-                            'result' => 'success',
-                            'redirect' => $response['payment_link']
-                        );
-                    } else {
-                        $order->add_order_note(
-                            __('Failed to create payment in Dodo Payments: Invalid response', 'dodo-payments-for-woocommerce')
-                        );
-                        return array('result' => 'failure');
-                    }
+                if (empty($response['checkout_url'])) {
+                    $order->add_order_note(
+                        __('Failed to create checkout session in Dodo Payments: Invalid response', 'dodo-payments-for-woocommerce')
+                    );
+                    return array('result' => 'failure');
                 }
+
+                $order->add_order_note(
+                    sprintf(
+                        // translators: %1$s: Checkout session ID
+                        __('Checkout session created in Dodo Payments: %1$s', 'dodo-payments-for-woocommerce'),
+                        isset($response['session_id']) ? $response['session_id'] : ''
+                    )
+                );
+
+                return array(
+                    'result' => 'success',
+                    'redirect' => $response['checkout_url'],
+                );
             }
 
             /**
@@ -887,6 +850,17 @@ function dodo_payments_init()
                 $payment_id = $payload['data']['payment_id'];
                 $order_id = Dodo_Payments_Payment_DB::get_order_id($payment_id);
 
+                // Fallback for checkout-sessions flow: payment_id is unknown at
+                // order-placement time, so the mapping is created lazily from the
+                // metadata we attached on the checkout session.
+                if (!$order_id) {
+                    $order_id = $this->resolve_order_id_from_metadata($payload);
+
+                    if ($order_id) {
+                        Dodo_Payments_Payment_DB::save_mapping($order_id, $payment_id);
+                    }
+                }
+
                 if (!$order_id) {
                     error_log('Dodo Payments: Could not find order_id for payment: ' . $payment_id);
                     return;
@@ -908,7 +882,19 @@ function dodo_payments_init()
                             $subscription_id = $payload['data']['subscription_id'];
                             $wc_subscription_id = Dodo_Payments_Subscription_DB::get_wc_subscription_id($subscription_id);
 
-                            if (function_exists('wcs_get_subscription')) {
+                            // Lazy mapping for checkout-sessions: rely on the
+                            // wc_subscription_id metadata we attached when creating
+                            // the checkout session.
+                            if (!$wc_subscription_id) {
+                                $wc_subscription_id = $this->resolve_wc_subscription_id_from_metadata($payload);
+
+                                if ($wc_subscription_id) {
+                                    Dodo_Payments_Subscription_DB::save_mapping($wc_subscription_id, $subscription_id);
+                                }
+                            }
+
+                            $subscription = null;
+                            if ($wc_subscription_id && function_exists('wcs_get_subscription')) {
                                 $subscription = wcs_get_subscription($wc_subscription_id);
                             }
 
@@ -957,6 +943,14 @@ function dodo_payments_init()
             {
                 $payment_id = $payload['data']['payment_id'];
                 $order_id = Dodo_Payments_Payment_DB::get_order_id($payment_id);
+
+                if (!$order_id) {
+                    $order_id = $this->resolve_order_id_from_metadata($payload);
+
+                    if ($order_id) {
+                        Dodo_Payments_Payment_DB::save_mapping($order_id, $payment_id);
+                    }
+                }
 
                 if (!$order_id) {
                     error_log('Dodo Payments: Could not find order for payment: ' . $payment_id);
@@ -1020,6 +1014,16 @@ function dodo_payments_init()
 
                 $subscription_id = $payload['data']['subscription_id'];
                 $wc_subscription_id = Dodo_Payments_Subscription_DB::get_wc_subscription_id($subscription_id);
+
+                // Fallback for checkout-sessions flow: the mapping is created
+                // lazily from the metadata we attached on the checkout session.
+                if (!$wc_subscription_id) {
+                    $wc_subscription_id = $this->resolve_wc_subscription_id_from_metadata($payload);
+
+                    if ($wc_subscription_id) {
+                        Dodo_Payments_Subscription_DB::save_mapping($wc_subscription_id, $subscription_id);
+                    }
+                }
 
                 if (!$wc_subscription_id) {
                     error_log('Dodo Payments: Could not find WooCommerce subscription for Dodo subscription: ' . $subscription_id);
@@ -1115,6 +1119,70 @@ function dodo_payments_init()
                         $subscription->add_order_note(__('Subscription renewed by Dodo Payments', 'dodo-payments-for-woocommerce'));
                     }
                 }
+            }
+
+            /**
+             * Resolve a WooCommerce order ID from the metadata attached to a webhook payload.
+             *
+             * The checkout-sessions API does not return payment_id/subscription_id at
+             * creation time, so we attach `wc_order_id` to the session's metadata and
+             * read it back here to bootstrap the local DB mapping on the first webhook.
+             *
+             * @param array $payload Webhook payload.
+             * @return int|null
+             */
+            private function resolve_order_id_from_metadata($payload)
+            {
+                if (!isset($payload['data']['metadata']) || !is_array($payload['data']['metadata'])) {
+                    return null;
+                }
+
+                $metadata = $payload['data']['metadata'];
+
+                if (!isset($metadata['wc_order_id'])) {
+                    return null;
+                }
+
+                $order_id = (int) $metadata['wc_order_id'];
+                if ($order_id <= 0) {
+                    return null;
+                }
+
+                if (!wc_get_order($order_id)) {
+                    return null;
+                }
+
+                return $order_id;
+            }
+
+            /**
+             * Resolve a WooCommerce subscription ID from the metadata attached to a webhook payload.
+             *
+             * @param array $payload Webhook payload.
+             * @return int|null
+             */
+            private function resolve_wc_subscription_id_from_metadata($payload)
+            {
+                if (!isset($payload['data']['metadata']) || !is_array($payload['data']['metadata'])) {
+                    return null;
+                }
+
+                $metadata = $payload['data']['metadata'];
+
+                if (!isset($metadata['wc_subscription_id'])) {
+                    return null;
+                }
+
+                $wc_subscription_id = (int) $metadata['wc_subscription_id'];
+                if ($wc_subscription_id <= 0) {
+                    return null;
+                }
+
+                if (!function_exists('wcs_get_subscription') || !wcs_get_subscription($wc_subscription_id)) {
+                    return null;
+                }
+
+                return $wc_subscription_id;
             }
 
             /**

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -174,9 +174,10 @@ class Dodo_Payments_API
      * per-item `amount` override) or a subscription product; the API resolves the flow based on
      * the products' configuration.
      *
-     * All `billing_address` fields (except `country`) and `customer.name` are nullable in the
-     * Checkout Sessions schema, so WooCommerce values are forwarded verbatim -- empty strings
-     * included -- and the hosted Dodo checkout will collect anything that's still missing.
+     * `billing_address.country` is the only required billing field per the Checkout
+     * Sessions schema; every other `billing_address` field and `customer.name` are
+     * nullable, so WooCommerce values are forwarded verbatim -- empty strings included --
+     * and the hosted Dodo checkout will collect anything else that's still missing.
      *
      * @param WC_Order $order The WooCommerce order to use for checkout details.
      * @param array{amount: int|null, product_id: string, quantity: int}[] $synced_products List of products to include in the checkout.
@@ -184,7 +185,7 @@ class Dodo_Payments_API
      * @param string $return_url URL to redirect the customer after checkout completion.
      * @param array<string, string> $metadata Metadata to associate with the checkout (used by webhooks to resolve the WC order/subscription).
      * @param array{on_demand?: array{mandate_only: bool}, trial_period_days?: int}|null $subscription_data Optional subscription configuration (e.g. mandate-only authorization).
-     * @throws \Exception If the API request fails or returns an error.
+     * @throws \Exception If the order has no billing country or the API request fails.
      * @return array{session_id: string, checkout_url: string|null} The created checkout session.
      */
     public function create_checkout_session(
@@ -195,10 +196,18 @@ class Dodo_Payments_API
         $metadata = array(),
         $subscription_data = null
     ) {
+        // billing_address.country is the only required field inside billing_address
+        // per the Checkout Sessions schema. Fail fast with a clear message rather
+        // than ship an obviously-invalid request and surface an opaque 422.
+        $billing_country = $order->get_billing_country();
+        if (empty($billing_country)) {
+            throw new Exception('Failed to create checkout session: billing country is required.');
+        }
+
         $request = array(
             'billing_address' => array(
                 'city' => $order->get_billing_city(),
-                'country' => $order->get_billing_country(),
+                'country' => $billing_country,
                 'state' => $order->get_billing_state(),
                 'street' => trim($order->get_billing_address_1() . ' ' . $order->get_billing_address_2()),
                 'zipcode' => $order->get_billing_postcode(),

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -166,45 +166,71 @@ class Dodo_Payments_API
     }
 
     /**
-     * Creates a payment in the Dodo Payments API using WooCommerce order data.
+     * Creates a checkout session in the Dodo Payments API using WooCommerce order data.
      *
-     * Builds a payment request with billing and customer information, a list of synced products, an optional discount code, and a return URL. Returns the payment ID and payment link on success.
+     * Replaces the deprecated `POST /payments` and `POST /subscriptions` endpoints with the
+     * unified `POST /checkouts` endpoint that handles both one-time payments and subscriptions
+     * via a single product cart. The cart may contain either one-time products (which honor the
+     * per-item `amount` override) or a subscription product; the API resolves the flow based on
+     * the products' configuration.
      *
-     * @param WC_Order $order The WooCommerce order to use for payment details.
-     * @param array{amount: mixed, product_id: string, quantity: mixed}[] $synced_products List of products to include in the payment.
+     * All `billing_address` fields (except `country`) and `customer.name` are nullable in the
+     * Checkout Sessions schema, so WooCommerce values are forwarded verbatim -- empty strings
+     * included -- and the hosted Dodo checkout will collect anything that's still missing.
+     *
+     * @param WC_Order $order The WooCommerce order to use for checkout details.
+     * @param array{amount: int|null, product_id: string, quantity: int}[] $synced_products List of products to include in the checkout.
      * @param string|null $dodo_discount_code Optional discount code to apply.
-     * @param string $return_url URL to redirect the customer after payment completion.
+     * @param string $return_url URL to redirect the customer after checkout completion.
+     * @param array<string, string> $metadata Metadata to associate with the checkout (used by webhooks to resolve the WC order/subscription).
+     * @param array{on_demand?: array{mandate_only: bool}, trial_period_days?: int}|null $subscription_data Optional subscription configuration (e.g. mandate-only authorization).
      * @throws \Exception If the API request fails or returns an error.
-     * @return array{payment_id: string, payment_link: string} The created payment's ID and payment link.
+     * @return array{session_id: string, checkout_url: string|null} The created checkout session.
      */
-    public function create_payment($order, $synced_products, $dodo_discount_code, $return_url)
-    {
+    public function create_checkout_session(
+        $order,
+        $synced_products,
+        $dodo_discount_code,
+        $return_url,
+        $metadata = array(),
+        $subscription_data = null
+    ) {
         $request = array(
-            'billing' => array(
+            'billing_address' => array(
                 'city' => $order->get_billing_city(),
                 'country' => $order->get_billing_country(),
                 'state' => $order->get_billing_state(),
-                'street' => $order->get_billing_address_1() . ' ' . $order->get_billing_address_2(),
+                'street' => trim($order->get_billing_address_1() . ' ' . $order->get_billing_address_2()),
                 'zipcode' => $order->get_billing_postcode(),
             ),
             'customer' => array(
                 'email' => $order->get_billing_email(),
-                'name' => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
+                'name' => trim($order->get_billing_first_name() . ' ' . $order->get_billing_last_name()),
             ),
             'product_cart' => $synced_products,
-            'discount_code' => $dodo_discount_code,
-            'payment_link' => true,
             'return_url' => $return_url,
         );
 
-        $res = $this->post('/payments', $request);
+        if ($dodo_discount_code) {
+            $request['discount_code'] = $dodo_discount_code;
+        }
+
+        if (!empty($metadata)) {
+            $request['metadata'] = $metadata;
+        }
+
+        if ($subscription_data !== null) {
+            $request['subscription_data'] = $subscription_data;
+        }
+
+        $res = $this->post('/checkouts', $request);
 
         if (is_wp_error($res)) {
-            throw new Exception("Failed to create payment: " . esc_html($res->get_error_message()));
+            throw new Exception('Failed to create checkout session: ' . esc_html($res->get_error_message()));
         }
 
         if (wp_remote_retrieve_response_code($res) !== 200) {
-            throw new Exception("Failed to create payment: " . esc_html($res['body']));
+            throw new Exception('Failed to create checkout session: ' . esc_html($res['body']));
         }
 
         return json_decode($res['body'], true);
@@ -618,75 +644,6 @@ class Dodo_Payments_API
         }
 
         return;
-    }
-
-    /**
-     * Creates a new subscription in the Dodo Payments API using WooCommerce order and product data.
-     *
-     * Builds and sends a subscription creation request with customer, billing, product, and optional discount information. Supports generating a payment link for checkout and an optional mandate-only mode for payment authorization without immediate charge.
-     *
-     * @param WC_Order $order WooCommerce order containing customer and billing details.
-     * @param array $synced_products Array of product data synced with the Dodo Payments API.
-     * @param string|null $dodo_discount_code Optional discount code to apply to the subscription.
-     * @param string $return_url URL to redirect the customer after subscription completion.
-     * @param bool $mandate_only If true, only authorizes the payment method without charging immediately.
-     * @throws \Exception If the API request fails or returns an error response.
-     * @return array{
-     *    subscription_id: string,
-     *    payment_id: string,
-     *    payment_link: string,
-     * } Subscription creation result including IDs and payment link.
-     */
-    public function create_subscription($order, $synced_products, $dodo_discount_code, $return_url, $mandate_only = false)
-    {
-        // Get the first product (subscriptions typically have one product)
-        $first_product = $synced_products[0];
-
-        $request = array(
-            'billing' => array(
-                'city' => $order->get_billing_city(),
-                'country' => $order->get_billing_country(),
-                'state' => $order->get_billing_state(),
-                'street' => $order->get_billing_address_1() . ' ' . $order->get_billing_address_2(),
-                'zipcode' => $order->get_billing_postcode(),
-            ),
-            'customer' => array(
-                'email' => $order->get_billing_email(),
-                'name' => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
-            ),
-            'product_id' => $first_product['product_id'],
-            'quantity' => $first_product['quantity'],
-        );
-
-        // Add discount if provided
-        if ($dodo_discount_code) {
-            $request['discount_code'] = $dodo_discount_code;
-        }
-
-        // Add payment link and return URL for checkout flow
-        if ($return_url) {
-            $request['payment_link'] = true;
-            $request['return_url'] = $return_url;
-        }
-
-        // Add on-demand subscription configuration if mandate_only is true
-        if ($mandate_only) {
-            $request['on_demand'] = array(
-                'mandate_only' => true,
-            );
-        }
-
-        $res = $this->post('/subscriptions', $request);
-
-        if (is_wp_error($res)) {
-            throw new Exception("Failed to create subscription: " . esc_html($res->get_error_message()));
-        }
-
-        if (wp_remote_retrieve_response_code($res) !== 200) {
-            throw new Exception("Failed to create subscription: " . esc_html($res['body']));
-        }
-
-        return json_decode($res['body'], true);
     }
 
     /**

--- a/includes/class-dodo-payments-api.php
+++ b/includes/class-dodo-payments-api.php
@@ -211,6 +211,11 @@ class Dodo_Payments_API
             'return_url' => $return_url,
         );
 
+        $tax_id = self::get_order_tax_id($order);
+        if ($tax_id !== null) {
+            $request['tax_id'] = $tax_id;
+        }
+
         if ($dodo_discount_code) {
             $request['discount_code'] = $dodo_discount_code;
         }
@@ -234,6 +239,45 @@ class Dodo_Payments_API
         }
 
         return json_decode($res['body'], true);
+    }
+
+    /**
+     * Best-effort lookup of the customer's tax ID / VAT number from a WC order.
+     *
+     * WooCommerce core does not collect a tax ID on its checkout form; the value
+     * comes from third-party VAT extensions, each of which uses its own order
+     * meta key. This helper checks the three most widely-used keys in the
+     * WooCommerce ecosystem and returns the first non-empty match.
+     *
+     * The list is intentionally short -- adding every long-tail key risks
+     * picking up the wrong field on stores running multiple extensions. Stores
+     * using a non-standard key can extend the list via the
+     * `dodo_payments_order_tax_id_meta_keys` filter without forking the plugin.
+     *
+     * Priority order (highest signal first):
+     *   1. `_billing_vat_number` -- WooCommerce EU VAT Number (official woocommerce.com extension)
+     *   2. `_billing_eu_vat_number` -- EU VAT for WooCommerce (WP Whale / Algoritmika)
+     *   3. `_billing_vat_id` -- Germanized Pro
+     *
+     * @param WC_Order $order
+     * @return string|null Trimmed tax ID, or null when none of the keys carry a value.
+     */
+    private static function get_order_tax_id($order)
+    {
+        $keys = apply_filters('dodo_payments_order_tax_id_meta_keys', array(
+            '_billing_vat_number',
+            '_billing_eu_vat_number',
+            '_billing_vat_id',
+        ), $order);
+
+        foreach ($keys as $key) {
+            $value = $order->get_meta($key, true);
+            if (is_string($value) && trim($value) !== '') {
+                return trim($value);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ayushdodopayments
 Tags: payments, woocommerce, dodo payments, merchant of record, subscriptions
 Requires at least: 6.1
 Tested up to: 6.9
-Stable tag: 0.3.5
+Stable tag: 0.4.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## Summary

Migrates the plugin from the now-deprecated `POST /payments` and `POST /subscriptions` endpoints onto the unified `POST /checkouts` (Checkout Sessions) API.

Docs followed: <https://docs.dodopayments.com/api-reference/checkout-sessions/create>.

## Changes

### API layer — `includes/class-dodo-payments-api.php`
- Removed `create_payment()` and `create_subscription()`.
- Added `create_checkout_session($order, $synced_products, $discount_code, $return_url, $metadata, $subscription_data)` which calls `POST /checkouts`.
- One unified code path handles both one-time and subscription orders — the API infers the flow from the products in the cart.
- `billing_address` and `customer` fields are forwarded verbatim from the WC order. The Checkout Sessions schema treats `billing_address` fields (except `country`) and `customer.name` as nullable, so empty WC values pass through unchanged.
- `subscription_data.on_demand.mandate_only` is exposed for callers that need mandate-only authorization (matches the old `mandate_only` parameter).

### Gateway — `dodo-payments-for-woocommerce.php`
- `do_payment()` routes every order through the single checkout-session call and redirects to `checkout_url` (replacing the old `payment_link`).
- Passes `wc_order_id` (and `wc_subscription_id`, when applicable) in `metadata`. The deprecated endpoints returned `payment_id` / `subscription_id` synchronously; checkout sessions don't, so this is the bridge that keeps webhook handling working.
- Webhook handlers (`handle_payment_webhook`, `handle_refund_webhook`, `handle_subscription_webhook`) now fall back to reading those IDs from `payload.data.metadata` and create the local DB mapping lazily on the first inbound event.

### Out of scope
This PR does **not** change WooCommerce's checkout-field validation. The plugin does not touch `woocommerce_billing_fields`, `woocommerce_checkout_fields`, or `woocommerce_get_country_locale`. Any merchant who wants to relax billing-field requirements when delegating address collection to the hosted Dodo checkout can do so explicitly in their own theme/plugin code; it is not implicitly applied by installing this gateway.

### Docs / version
- Bumped to `0.4.0` (header, `readme.txt` stable tag).
- Added changelog entry.

## Webhook compatibility

Existing stores with pre-existing payment/subscription DB mappings continue to work — the webhook handlers still check the DB first. The metadata fallback only activates when the lookup misses, which is the new-flow case where no mapping was saved at order-creation time.

## Verification

- `php -l` passes on both modified PHP files.
- No remaining references to the deprecated `create_payment` / `create_subscription` methods or `POST /payments` / `POST /subscriptions` paths (only doc comments).
- No call sites for the deprecated methods remain.

Marked as **draft** for review before merge — runtime verification against a live Dodo Payments test account is still pending.